### PR TITLE
修复鼠标导航的一部分按钮 `name` 属性为空的问题

### DIFF
--- a/addon/appModules/wechat.py
+++ b/addon/appModules/wechat.py
@@ -105,6 +105,15 @@ class AppModule(appModuleHandler.AppModule):
 
 		nextHandler()
 
+	def event_mouseMove(self, obj: NVDAObject, nextHandler):
+		if obj.role == role.BUTTON and obj.name == "" and obj.previous.role == role.PANE:
+			for child in obj.previous.children:
+				if child.role == role.STATICTEXT and child.name != "":
+					obj.name = child.name
+					break
+		nextHandler()
+
+
 	@script(
 		description="是否自动朗读新消息",
 		category="PC微信增强",


### PR DESCRIPTION
我也考虑过使用祖先列表对象的 `name` 属性的方案，但这对文章链接不适用。